### PR TITLE
Checking domain string is unnecessary, causes failures

### DIFF
--- a/acm.py
+++ b/acm.py
@@ -62,9 +62,6 @@ def validate(event, context):
             % (region, account_id, cert_id))
         logging.debug(cert)
 
-        if cert['Certificate']['DomainName'] != domain:
-            panic("Couldn't match confirmation to certificate domain!")
-
         if cert['Certificate']['Status'] != 'PENDING_VALIDATION':
             panic("Confirmation certificate is not pending validation!")
 


### PR DESCRIPTION
We're already checking that the certificate ARN is correct, and the
cert is pending validation. Checking the domain string is gilding the
lily and is the source of many failures: It doesn't work for wildcard
certs, or certs with numerous domains.

Fixes #2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kounta/lambda-acm-validate/3)
<!-- Reviewable:end -->
