### PR TITLE
Ignore emails that don't match the cert confirm URL

### DIFF
--- a/acm.py
+++ b/acm.py
@@ -28,58 +28,58 @@ def panic(msg):
 def validate(event, context):
     msg = json.loads(event['Records'][0]['Sns']['Message'])
     match = confirm_url.search(msg['content'])
+
+    # Ignore emails that don't match the certificate confirm URL
+    if !match:
+        return
+
+    url = match.group(0)
+    logging.info("CONFIRMATION URL: %s" % url)
+
+    br = mechanize.Browser()
+    br.set_handle_robots(False)
+
+    # Fetch approval page
+    logging.debug("OPENING CONFIRMATION URL")
+    response = br.open(url)
+    logging.debug("OPENED CONFIRMATION URL")
+    content = response.get_data()
+
+    # Extract confirmation page details
+    domain, account_id, region, cert_id = [regex.match(content).group(1)
+        if regex.match(content) else panic("Couldn't parse confirmation page!")
+        for regex in (domain_re, accountid_re, region_re, certid_re)]
+
+    # Remove dashes from account_id
+    account_id = account_id.translate(None, '-')
+
+    # Always log what we're confirming
+    print("Validation URL: '%s'" % url)
+    print("Domain: '%s'" % domain)
+    print("Account ID: '%s'" % account_id)
+    print("Region: '%s'" % region)
+    print("Certificate ID: '%s'" % cert_id)
+
+    # Check if the cert is pending validation
+    acm = boto3.client('acm', region_name=region)
+    cert = acm.describe_certificate(CertificateArn="arn:aws:acm:%s:%s:certificate/%s"
+        % (region, account_id, cert_id))
+    logging.debug(cert)
+
+    if cert['Certificate']['Status'] != 'PENDING_VALIDATION':
+        panic("Confirmation certificate is not pending validation!")
+
+    # It's the first and only form on the page
+    # Could we match on action="/approvals"?
+    br.select_form(nr=0)
+    logging.info("SUBMITTING CONFIRMATION FORM")
+    response = br.submit(name='commit')
+    logging.info("SUBMITTED CONFIRMATION FORM")
+    content = response.get_data()
+
+    match = approval_text.search(content)
     if match:
-        url = match.group(0)
-        logging.info("CONFIRMATION URL: %s" % url)
-
-        br = mechanize.Browser()
-        br.set_handle_robots(False)
-
-        # Fetch approval page
-        logging.debug("OPENING CONFIRMATION URL")
-        response = br.open(url)
-        logging.debug("OPENED CONFIRMATION URL")
-        content = response.get_data()
-
-        # Extract confirmation page details
-        domain, account_id, region, cert_id = [regex.match(content).group(1)
-            if regex.match(content) else panic("Couldn't parse confirmation page!")
-            for regex in (domain_re, accountid_re, region_re, certid_re)]
-
-        # Remove dashes from account_id
-        account_id = account_id.translate(None, '-')
-
-        # Always log what we're confirming
-        print("Validation URL: '%s'" % url)
-        print("Domain: '%s'" % domain)
-        print("Account ID: '%s'" % account_id)
-        print("Region: '%s'" % region)
-        print("Certificate ID: '%s'" % cert_id)
-
-        # Check if the cert is pending validation
-        acm = boto3.client('acm', region_name=region)
-        cert = acm.describe_certificate(CertificateArn="arn:aws:acm:%s:%s:certificate/%s"
-            % (region, account_id, cert_id))
-        logging.debug(cert)
-
-        if cert['Certificate']['Status'] != 'PENDING_VALIDATION':
-            panic("Confirmation certificate is not pending validation!")
-
-        # It's the first and only form on the page
-        # Could we match on action="/approvals"?
-        br.select_form(nr=0)
-        logging.info("SUBMITTING CONFIRMATION FORM")
-        response = br.submit(name='commit')
-        logging.info("SUBMITTED CONFIRMATION FORM")
-        content = response.get_data()
-
-        match = approval_text.search(content)
-        if match:
-            print("Certificate for %s approved!" % domain)
-        else:
-            logging.error(content)
-            panic("No confirmation of certificate approval!")
-
+        print("Certificate for %s approved!" % domain)
     else:
-        logging.error(msg['content'])
-        panic("Email did not match certificate approval URL!")
+        logging.error(content)
+        panic("No confirmation of certificate approval!")


### PR DESCRIPTION
There's an argument to be made that we should log the content of
ignored emails, but let's just ignore them entirely for now.

Fixes #1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kounta/lambda-acm-validate/4)
<!-- Reviewable:end -->
